### PR TITLE
Fix depth argument for toctree

### DIFF
--- a/src/sphinx_py3doc_enhanced_theme/globaltoc.html
+++ b/src/sphinx_py3doc_enhanced_theme/globaltoc.html
@@ -1,2 +1,2 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('Table Of Contents') }}</a></h3>
-{{ toctree(maxdepth=theme_sidebardepth, collapse=theme_sidebarcollapse, includehidden=True) }}
+{{ toctree(maxdepth=theme_sidebardepth|int, collapse=theme_sidebarcollapse, includehidden=True) }}


### PR DESCRIPTION
The depth must be an integer. This only leads to an exception in Python 3, where comparing str and int is not allowed. In Python 2, it leads to "strange" behavior where `"2" > 1` but also `"0" > 1` since the types are compared by type name.
