### PR TITLE
Added options: head/code shadows, py3doc code, hilight sections, linkcolor, visitedlinkcolor

### DIFF
--- a/src/sphinx_py3doc_enhanced_theme/static/pydoctheme.css_t
+++ b/src/sphinx_py3doc_enhanced_theme/static/pydoctheme.css_t
@@ -97,17 +97,19 @@ div.body div.seealso {
     border: 1px solid #dddd66;
 }
 
+    /* color: {{ theme_linkcolor }}; */
 div.body a {
-    color: #00608f;
+    color: {{ theme_linkcolor }};
 }
 
 div.body a:visited {
-    color: #30306f;
+    color: {{ theme_visitedlinkcolor }};
 }
 
 div.body a:hover {
     color: #00B0E4;
 }
+{% if theme_highlightcurrent %}
 div.body .section:target > h1,
 div.body .section:target > h2,
 div.body .section:target > h3,
@@ -126,7 +128,7 @@ div.body span:target + h5 {
     margin-left: -10px;
     text-shadow: 1px 1px 0px rgba(255,255,255,0.6);
 }
-
+{% endif %}
 
 tt, pre {
     font-family: monospace, sans-serif;
@@ -208,6 +210,7 @@ div.sphinxsidebar,
 pre, code, tt {
     font-family: {{ theme_codefont }} !important;
 }
+{% if theme_newstylecode %}
 pre {
     border: 1px solid #ddd !important;
     background-color: #fffdfd !important;
@@ -222,6 +225,7 @@ pre {
     word-wrap: break-word !important;
     /* Internet Explorer 5.5+ */
 }
+{% endif %}
 div.viewcode-block:target {
     background-color: #FFF4E6 !important;
 }
@@ -284,13 +288,17 @@ li > img {
 }
 
 h1, h2, h3, h4, h5, h6 {
+    {% if theme_headshadow %}
     text-shadow: 1px 1px 2px #ddd;
+    {% endif %}
     font-weight: bold;
     color: #333;
 }
 code, tt {
     background: none;
+    {% if codeshadow %}
     text-shadow: 1px 1px 2px #ddd;
+    {% endif %}
     font-weight: bold;
 }
 div.sphinxsidebarwrapper > ul > li > ul > li {

--- a/src/sphinx_py3doc_enhanced_theme/theme.conf
+++ b/src/sphinx_py3doc_enhanced_theme/theme.conf
@@ -28,3 +28,7 @@ sidebardepth = 2
 sidebarcollapse = true
 githuburl =
 embedded = false
+headshadow = true
+newstylecode = true
+highlightcurrent = true
+codeshadow = true


### PR DESCRIPTION
I noticed that a bunch of the html_theme_options don't work, so I fixed a few to make it possible to tweak the theme closer to how the python 3 documentation looks. I use these html_theme_options copied from python's repository (some of which, I'm sure, are redundant):

```
html_theme_options = {
    'bodyfont': '\'Lucida Grande\', Arial, sans-serif',
    'headfont': '\'Lucida Grande\', Arial, sans-serif',
    'footerbgcolor': 'white',
    'footertextcolor': '#555555',
    'relbarbgcolor': 'white',
    'relbartextcolor': '#666666',
    'relbarlinkcolor': '#444444',
    'sidebarbgcolor': 'white',
    'sidebartextcolor': '#444444',
    'sidebarlinkcolor': '#444444',
    'bgcolor': 'white',
    'textcolor': '#222222',
    'linkcolor': '#0072AA',
    'visitedlinkcolor': '#6363bb',
    'headtextcolor': '#1a1a1a',
    'headbgcolor': 'white',
    'headlinkcolor': '#aaaaaa',
    'headshadow': False,
    'codeshadow': False,
    'newstylecode': False,
    'highlightcurrent': False
    }
```
