### PR TITLE
Add codeclassname_bold and headercode_bold theme options

### DIFF
--- a/src/sphinx_py3doc_enhanced_theme/static/pydoctheme.css_t
+++ b/src/sphinx_py3doc_enhanced_theme/static/pydoctheme.css_t
@@ -144,6 +144,22 @@ div.body tt.descname {
     font-weight: bold;
 }
 
+{% if not theme_codeclassname_bold %}
+div.body code.descclassname {
+    font-weight: normal;
+}
+{% endif %}
+
+{% if not theme_headercode_bold %}
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code {
+    font-weight: normal;
+}
+{% endif %}
+
 div.body tt.xref, div.body a tt {
     font-weight: normal;
 }

--- a/src/sphinx_py3doc_enhanced_theme/theme.conf
+++ b/src/sphinx_py3doc_enhanced_theme/theme.conf
@@ -32,3 +32,5 @@ headshadow = true
 newstylecode = true
 highlightcurrent = true
 codeshadow = true
+codeclassname_bold = true
+headercode_bold = true


### PR DESCRIPTION
Adds two configuration options, to let user make docs look more like official Python3 docs (and, I think, to make things look nicer and cleaner).

`codeclassname_bold` makes it so class names aren't bolded. For instance, by default on pages like [this](https://docs.python.org/3.4/library/os.path.html#os.path.lexists), all those `os.path.` prefixes before each function are bolded (which doesn't look too nice, makes the functions blend together). Enabling this options makes them all unbolded as in the linked official docs.

`headercode_bold` makes it so that code blocks in headers aren't bolded. As an example, here's a header from the [official docs](https://docs.python.org/3.4/library/os.path.html#module-os.path). By default in this theme, the hyperlinked `os.path` would be bolded, which doesn't look that nice. Enabling this option makes it unbolded as shown in the linked official docs

If you think one or both of these should be put in the css by default instead of being options, please let me know. Otherwise, if this looks good I can do the rest of the steps in the PR Guidelines.
